### PR TITLE
Needs root in order to run.

### DIFF
--- a/telldus-core/service/tellstick.conf
+++ b/telldus-core/service/tellstick.conf
@@ -1,4 +1,4 @@
-user = "nobody"
+user = "root"
 group = "plugdev"
 ignoreControllerConfirmation = "false"
 device {


### PR DESCRIPTION
Using your fork in the addon and copying the default config file in to /config, it would be best if we could enable it in the git directly otherwise we have to hack in the add-on installation with search and replace.